### PR TITLE
Add Team Rep page for handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Pages will be added here as they are created or updated on the handbook site.
 ## Table of Contents
 - [Homepage](homepage.md): https://make.wordpress.org/test/handbook/
 - [Test Reports](test-reports.md): https://make.wordpress.org/test/handbook/test-reports/
+- [Team Reps](team-reps.md): https://make.wordpress.org/test/handbook/team-reps/
 - [Get Started at Contributor Day](contributor-day.md): https://make.wordpress.org/test/handbook/get-started-at-contributor-day/
 
 ## Contributing

--- a/team-reps.md
+++ b/team-reps.md
@@ -1,0 +1,58 @@
+# Test Team Reps
+
+For a quick refresher of Team Rep roles across the project, please see the [official Team Reps post on Team Updates](https://make.wordpress.org/updates/team-reps/).
+
+## The Role
+
+Reps in the Test Team perform primary and secondary (or backup) duties to help support team chats, make updates to the team’s blog and handbook, remove blockers, keep a pulse on team objectives, and promote testing opportunities within the WordPress project.
+
+<div class="callout callout-info">
+As a reminder, **Reps are not called “team leads” for a reason**. While people elected as Team Reps generally come from the pool of folks that people think of as experienced leaders, the Team Rep role is designed to change hands regularly.
+</div>
+
+Test Team Rep duties include:
+
+- Write weekly [Test Team Update](https://make.wordpress.org/updates/tag/test/) posts, and post to [Team Updates](https://make.wordpress.org/updates/).
+- Write weekly [Week in Test](https://make.wordpress.org/test/category/week-in-test/) posts, and post to [Make WordPress Test](https://make.wordpress.org/test/).
+- Write agenda for bi-weekly `<test-chat>` sessions ([example](https://make.wordpress.org/test/2021/07/19/test-chat-agenda-for-july-20-2021/)).
+- Run alternating weekly `<test-chat>` ([example](https://wordpress.slack.com/archives/C03B0H5J0/p1626181220122300)) and `<test-triage>` ([example](https://wordpress.slack.com/archives/C03B0H5J0/p1625576610036600)) sessions in [#core-test](https://wordpress.slack.com/messages/core-test/).
+- Write `<test-chat>` session recaps, and post to [Make WordPress Test](https://make.wordpress.org/test/).
+- Help raise awareness for testing needs, especially for upcoming releases.
+- Raise issues or red flags that other teams should be aware of or discussing.
+- Participate in quarterly update progress reports ([example](https://make.wordpress.org/updates/2021/04/15/quarterly-updates-q1-2021/)).
+
+These duties are shared between the primary and secondary Reps (see **Rep Responsibilities** on [the Team Rep page](https://make.wordpress.org/updates/team-reps/#team-rep-orientation)).
+
+### Qualifications
+
+A Rep is an active team member who is reliable and trusted, advocates for and is knowledgeable of one or more areas of testing, and wants to represent, nurture, and grow the team to better serve the WordPress open source project.
+
+Test Team Reps must be committed to showing up and performing regular duties, and should expect a time commitment of at least 2-4 hours per week. Reps serve for a term of one year, and should swap their primary and secondary responsibilities after six months.
+
+## How Test Team Elections Work
+
+### Step 1: Call for Nominations
+
+The first step is to reach out to the community with a Call for Nominations, such as these examples from [2021](https://make.wordpress.org/test/2021/07/20/test-team-reps-call-for-nominations/) and [2022](https://make.wordpress.org/test/2022/08/10/test-team-reps-call-for-nominations-2/).
+
+Nominations are given in the comments of the post. A simple, “I nominate `@the_persons_username`” is sufficient. Self-nominations are also welcome by leaving a comment such as, “I nominate myself.”
+
+Private nominations can be submitted anonymously by contacting the current Test Team Reps via DM in Slack.
+
+### Step 2: Accept Nominations
+
+The nomination period typically lasts two weeks, during which time contributors who have been nominated are asked to clearly _accept_ or _decline_ the nomination as a reply to the nominating comment. For instance, "I accept this nomination," or "I decline this nomination."
+
+After the deadline, each nominee will be contacted by a current Test Team Reps to discuss qualifications and to confirm their acceptance of the nomination.
+
+Nominees should not feel obligated to accept their nomination. It’s okay to decline for any reason. An example response might be, “Thank you, but not this year!”
+
+### Step 3: Vote for Team Reps
+
+An election to vote for the final Test Team Reps will happen only if there are more than two accepted nominations within the nomination period; otherwise the nominees will become the new Test Team Reps.
+
+If held, the election should be conducted by an anonymous poll ([example](https://make.wordpress.org/community/2020/12/01/community-team-reps-submit-your-votes-2/)). The poll should remain open for two weeks.
+
+### Step 4: Announce Team Reps
+
+Once uncontested nominations have been accepted, or in the event of an election the voting period has passed, the new Test Team Reps should be announced in a post, such as [this example from 2021](https://make.wordpress.org/test/2021/08/03/test-team-reps-for-2021/).

--- a/team-reps.md
+++ b/team-reps.md
@@ -39,7 +39,7 @@ Test Team Reps must be committed to showing up and performing regular duties, an
 
 The first step is to reach out to the community with a Call for Nominations, such as these examples from [2021](https://make.wordpress.org/test/2021/07/20/test-team-reps-call-for-nominations/) and [2022](https://make.wordpress.org/test/2022/08/10/test-team-reps-call-for-nominations-2/). Nominations are held each August, with the new term starting by September.
 
-Nominations are given in the comments of the post. A simple, “I nominate `@the_persons_username`” is sufficient. Self-nominations are also welcome by leaving a comment such as, “I nominate myself.”
+Nominations should be given in the comments of the post. A simple, “I nominate `@the_persons_username`” is sufficient. Self-nominations are also welcome by leaving a comment such as, “I nominate myself.”
 
 Private nominations can be submitted anonymously by contacting the current Test Team Reps via DM in Slack.
 

--- a/team-reps.md
+++ b/team-reps.md
@@ -2,6 +2,10 @@
 
 For a quick refresher of Team Rep roles across the project, please see the [official Team Reps post on Team Updates](https://make.wordpress.org/updates/team-reps/).
 
+## Current Reps
+
+The Test Team Reps for the 2022-2023 term are @boniu91 and @ironprogrammer.
+
 ## The Role
 
 Reps in the Test Team perform primary and secondary (or backup) duties to help support team chats, make updates to the team’s blog and handbook, remove blockers, keep a pulse on team objectives, and promote testing opportunities within the WordPress project.

--- a/team-reps.md
+++ b/team-reps.md
@@ -37,7 +37,7 @@ Test Team Reps must be committed to showing up and performing regular duties, an
 
 ### Step 1: Call for Nominations
 
-The first step is to reach out to the community with a Call for Nominations, such as these examples from [2021](https://make.wordpress.org/test/2021/07/20/test-team-reps-call-for-nominations/) and [2022](https://make.wordpress.org/test/2022/08/10/test-team-reps-call-for-nominations-2/).
+The first step is to reach out to the community with a Call for Nominations, such as these examples from [2021](https://make.wordpress.org/test/2021/07/20/test-team-reps-call-for-nominations/) and [2022](https://make.wordpress.org/test/2022/08/10/test-team-reps-call-for-nominations-2/). Nominations are held each August, with the new term starting by September.
 
 Nominations are given in the comments of the post. A simple, “I nominate `@the_persons_username`” is sufficient. Self-nominations are also welcome by leaving a comment such as, “I nominate myself.”
 

--- a/team-reps.md
+++ b/team-reps.md
@@ -4,7 +4,7 @@ For a quick refresher of Team Rep roles across the project, please see the [offi
 
 ## Current Reps
 
-The Test Team Reps for the 2022-2023 term are @boniu91 and @ironprogrammer.
+The Test Team Reps for the 2023-2024 term are @webtechpooja and @ankit-k-gupta.
 
 ## The Role
 


### PR DESCRIPTION
Adds Test Team Rep informational page to handbook. Content adapted from recent call for nominations posts (referenced in #6).

Fixes #6.
