### PR TITLE
Test Team Profile Badge Process

### DIFF
--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -17,7 +17,7 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
   
 ## Test Team Badge 
  
-If you are currently serving as a Test Team Rep or have served as a Test Lead in any major releases of WordPress, you are eligible for a Training Team Badge.
+If you have served as a Test Team Rep or Test Lead in any major release of WordPress, you are eligible for the Test Team badge.
 
 ## Requesting a profile badge
 

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -1,0 +1,28 @@
+# Test Team Profile Badges
+
+This page offers comprehensive information about Test Team Profile Badges and the process for requesting badges on your WordPress.org profile.
+
+## Test Contributor Badge
+
+To earn a Test Contributor Badge, you must have completed at least one of the following:
+
+- Submitted a test report comprising at least 3 tickets for [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/).
+- Reported a new issue on the core [Trac](https://core.trac.wordpress.org/tickets/latest) that has been merged into the WordPress release.
+- Submitted unit or end-to-end tests that have been merged.
+- Contributed to a [Test handbook](https://github.com/wordpress/test-handbook)  PR that has been merged.
+- Participated in ZIP package builds or default theme tests during a #core <release-party>.
+- Participated in a Contributor Day (as a table lead, providing technical support, or assisting with onboarding).
+- Suggested a thoughtful idea aimed at improving the quality of WordPress or enhancing the testing process in any way, which has been accepted.
+
+  
+## Test Team Badge 
+ 
+If you are currently serving as a Test Team Rep or have served as a Test Lead in any major releases of WordPress, you are eligible for a Training Team Badge.
+
+## Requesting a profile badge
+
+If you meet the criteria above, please request a badge using the buttons below. Kindly include any links to resources that demonstrate you have met the criteria mentioned above.
+
+[Request a Badge ](https://profiles.wordpress.org/associations/test-contributor/)                            
+
+A Test Team Reps will confirm your contribution and assign you a badge. There will be a monthly review of contributions and badges will be awarded at that time. The test team will post updates on new profile badges awarded on the [Test Team blog](https://make.wordpress.org/test/). 

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -10,7 +10,6 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
 - Reported an issue on [Core Trac](https://core.trac.wordpress.org/tickets/latest) or the [Gutenberg GitHub repo](https://github.com/wordpress/gutenberg/issues) whose fix has been merged into a WordPress release.
 - Submitted unit or end-to-end tests that have been merged.
 - Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
-- Participated in ZIP package builds or default theme tests during a `#core <release-party>`.
 - Participated in a [Contributor Day](https://make.wordpress.org/test/handbook/get-started-at-contributor-day/) as a table lead, providing technical support, or assisting with onboarding.
 - Suggested a thoughtful idea aimed at improving testing processes in any way, which gets implemented.
   

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -19,10 +19,10 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
  
 If you have served as a Test Team Rep or Test Lead in any major release of WordPress, you are eligible for the Test Team badge.
 
-## Requesting a profile badge
+## Requesting a Test Team Badge
 
 If you meet the criteria above, please request a badge using the buttons below. Kindly include any links to resources that demonstrate you have met the criteria mentioned above.
 
-[Request a Badge ](https://profiles.wordpress.org/associations/test-contributor/)                            
+[Request a Badge](https://profiles.wordpress.org/associations/test-contributor/)
 
-A Test Team Reps will confirm your contribution and assign you a badge. There will be a monthly review of contributions and badges will be awarded at that time. The test team will post updates on new profile badges awarded on the [Test Team blog](https://make.wordpress.org/test/). 
+Upon request, a Test Team Rep will confirm your contribution(s) and assign you a badge. There will be a monthly review of contributions and badges will be awarded at that time. The Test Team will post updates on new profile badges awarded on the [Test Team blog](https://make.wordpress.org/test/). 

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -9,7 +9,7 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
 - Submitted a test report comprising at least 3 tickets for [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/).
 - Reported a new issue on the core [Trac](https://core.trac.wordpress.org/tickets/latest) that has been merged into the WordPress release.
 - Submitted unit or end-to-end tests that have been merged.
-- Contributed to a [Test handbook](https://github.com/wordpress/test-handbook)  PR that has been merged.
+- Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
 - Participated in ZIP package builds or default theme tests during a #core <release-party>.
 - Participated in a Contributor Day (as a table lead, providing technical support, or assisting with onboarding).
 - Suggested a thoughtful idea aimed at improving the quality of WordPress or enhancing the testing process in any way, which has been accepted.

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -6,7 +6,7 @@ This page offers comprehensive information about Test Team [profile badges](http
 
 To earn a Test Contributor Badge, you must have completed at least one of the following:
 
-- Submitted a test report comprising at least 3 tickets for [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/) either on WordPress or Gutenberg. Please note that reports can be submitted, whether it's on Trac or GitHub.
+- Submitted test reports for least 3 tickets, comprising of [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), and/or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/). Acceptable reports should be submitted to Trac or GitHub, and can apply to any WordPress project area included in the [Test Team duty of care](https://make.wordpress.org/test/handbook/#duty-of-care).
 - Reported an issue on [Core Trac](https://core.trac.wordpress.org/tickets/latest) or the [Gutenberg GitHub repo](https://github.com/wordpress/gutenberg/issues) whose fix has been merged into a WordPress release.
 - Submitted unit or end-to-end tests that have been merged.
 - Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -13,7 +13,6 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
 - Participated in ZIP package builds or default theme tests during a `#core <release-party>`.
 - Participated in a Contributor Day (as a table lead, providing technical support, or assisting with onboarding).
 - Suggested a thoughtful idea aimed at improving testing processes in any way, which gets implemented.
-
   
 ## Test Team Badge 
  

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -10,7 +10,7 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
 - Reported a new issue on the core [Trac](https://core.trac.wordpress.org/tickets/latest) that has been merged into the WordPress release.
 - Submitted unit or end-to-end tests that have been merged.
 - Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
-- Participated in ZIP package builds or default theme tests during a #core <release-party>.
+- Participated in ZIP package builds or default theme tests during a `#core <release-party>`.
 - Participated in a Contributor Day (as a table lead, providing technical support, or assisting with onboarding).
 - Suggested a thoughtful idea aimed at improving the quality of WordPress or enhancing the testing process in any way, which has been accepted.
 

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -11,7 +11,7 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
 - Submitted unit or end-to-end tests that have been merged.
 - Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
 - Participated in ZIP package builds or default theme tests during a `#core <release-party>`.
-- Participated in a Contributor Day (as a table lead, providing technical support, or assisting with onboarding).
+- Participated in a [Contributor Day](https://make.wordpress.org/test/handbook/get-started-at-contributor-day/) as a table lead, providing technical support, or assisting with onboarding.
 - Suggested a thoughtful idea aimed at improving testing processes in any way, which gets implemented.
   
 ## Test Team Badge 

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -12,7 +12,7 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
 - Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
 - Participated in ZIP package builds or default theme tests during a `#core <release-party>`.
 - Participated in a Contributor Day (as a table lead, providing technical support, or assisting with onboarding).
-- Suggested a thoughtful idea aimed at improving the quality of WordPress or enhancing the testing process in any way, which has been accepted.
+- Suggested a thoughtful idea aimed at improving testing processes in any way, which gets implemented.
 
   
 ## Test Team Badge 

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -6,7 +6,7 @@ This page offers comprehensive information about Test Team [profile badges](http
 
 To earn a Test Contributor Badge, you must have completed at least one of the following:
 
-- Submitted a test report comprising at least 3 tickets for [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/).
+- Submitted a test report comprising at least 3 tickets for [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/) either on WordPress or Gutenberg. Please note that reports can be submitted, whether it's on Trac or GitHub.
 - Reported a new issue on the core [Trac](https://core.trac.wordpress.org/tickets/latest) that has been merged into the WordPress release.
 - Submitted unit or end-to-end tests that have been merged.
 - Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -8,6 +8,7 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
 
 - Submitted test reports for at least 1 ticket, comprising of [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), and/or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/). Acceptable reports should be submitted to Trac or GitHub, and can apply to any WordPress project area included in the [Test Team duty of care](https://make.wordpress.org/test/handbook/#duty-of-care).
 - Submitted unit or end-to-end tests that have been merged.
+- Contributed to a WordPress project test suite, such as [phpunit-test-runner](https://github.com/WordPress/phpunit-test-runner) or [phpunit-test-reporter](https://github.com/WordPress/phpunit-test-reporter), on a PR that has been merged.
 - Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
 - Participated in a [Contributor Day](https://make.wordpress.org/test/handbook/get-started-at-contributor-day/) as a Test table lead, providing technical support, or assisting with onboarding.
 - Suggested a thoughtful idea aimed at improving testing processes in any way, which gets implemented.

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -16,7 +16,7 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
   
 ## Test Team Badge 
  
-If you have served as a Test Team Rep or Test Lead in any major release of WordPress, you are eligible for the Test Team badge.
+If you have served as a Test Team Rep or Test Lead in any major release of WordPress, or have provided consistent substantial contributions to the Test Team, you are eligible for the Test Team badge.
 
 ## Requesting a Test Profile Badge
 

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -18,7 +18,7 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
  
 If you have served as a Test Team Rep or Test Lead in any major release of WordPress, you are eligible for the Test Team badge.
 
-## Requesting a Test Team Badge
+## Requesting a Test Profile Badge
 
 If you meet the criteria above, please request a badge using the buttons below. Kindly include any links to resources that demonstrate you have met the criteria mentioned above.
 

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -7,7 +7,7 @@ This page offers comprehensive information about Test Team [profile badges](http
 To earn a Test Contributor Badge, you must have completed at least one of the following:
 
 - Submitted a test report comprising at least 3 tickets for [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/) either on WordPress or Gutenberg. Please note that reports can be submitted, whether it's on Trac or GitHub.
-- Reported a new issue on the core [Trac](https://core.trac.wordpress.org/tickets/latest) that has been merged into the WordPress release.
+- Reported an issue on [Core Trac](https://core.trac.wordpress.org/tickets/latest) or the [Gutenberg GitHub repo](https://github.com/wordpress/gutenberg/issues) whose fix has been merged into a WordPress release.
 - Submitted unit or end-to-end tests that have been merged.
 - Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
 - Participated in ZIP package builds or default theme tests during a `#core <release-party>`.

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -1,6 +1,6 @@
 # Test Team Profile Badges
 
-This page offers comprehensive information about Test Team Profile Badges and the process for requesting badges on your WordPress.org profile.
+This page offers comprehensive information about Test Team [profile badges](https://make.wordpress.org/meta/handbook/tutorials-guides/profile-badges/) and the process for requesting these badges for your WordPress.org profile.
 
 ## Test Contributor Badge
 

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -9,7 +9,7 @@ To earn a Test Contributor Badge, you must have completed at least one of the fo
 - Submitted test reports for at least 1 ticket, comprising of [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), and/or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/). Acceptable reports should be submitted to Trac or GitHub, and can apply to any WordPress project area included in the [Test Team duty of care](https://make.wordpress.org/test/handbook/#duty-of-care).
 - Submitted unit or end-to-end tests that have been merged.
 - Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
-- Participated in a [Contributor Day](https://make.wordpress.org/test/handbook/get-started-at-contributor-day/) as a table lead, providing technical support, or assisting with onboarding.
+- Participated in a [Contributor Day](https://make.wordpress.org/test/handbook/get-started-at-contributor-day/) as a Test table lead, providing technical support, or assisting with onboarding.
 - Suggested a thoughtful idea aimed at improving testing processes in any way, which gets implemented.
   
 ## Test Team Badge 

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -6,8 +6,7 @@ This page offers comprehensive information about Test Team [profile badges](http
 
 To earn a Test Contributor Badge, you must have completed at least one of the following:
 
-- Submitted test reports for least 3 tickets, comprising of [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), and/or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/). Acceptable reports should be submitted to Trac or GitHub, and can apply to any WordPress project area included in the [Test Team duty of care](https://make.wordpress.org/test/handbook/#duty-of-care).
-- Reported an issue on [Core Trac](https://core.trac.wordpress.org/tickets/latest) or the [Gutenberg GitHub repo](https://github.com/wordpress/gutenberg/issues) whose fix has been merged into a WordPress release.
+- Submitted test reports for at least 1 ticket, comprising of [testing instructions](https://make.wordpress.org/test/handbook/test-reports/testing-instructions/), [issue reproduction](https://make.wordpress.org/test/handbook/test-reports/issue-reproduction/), and/or [patch testing](https://make.wordpress.org/test/handbook/test-reports/patch-testing/). Acceptable reports should be submitted to Trac or GitHub, and can apply to any WordPress project area included in the [Test Team duty of care](https://make.wordpress.org/test/handbook/#duty-of-care).
 - Submitted unit or end-to-end tests that have been merged.
 - Contributed to a [Test handbook](https://github.com/wordpress/test-handbook) PR that has been merged.
 - Participated in a [Contributor Day](https://make.wordpress.org/test/handbook/get-started-at-contributor-day/) as a table lead, providing technical support, or assisting with onboarding.

--- a/test-team-badge.md
+++ b/test-team-badge.md
@@ -22,6 +22,7 @@ If you have served as a Test Team Rep or Test Lead in any major release of WordP
 
 If you meet the criteria above, please request a badge using the buttons below. Kindly include any links to resources that demonstrate you have met the criteria mentioned above.
 
-[Request a Badge](https://profiles.wordpress.org/associations/test-contributor/)
+- [Request Test Contributor Badge](https://profiles.wordpress.org/associations/test-contributor/)
+- [Request Test Team Badge](https://profiles.wordpress.org/associations/test-team/)
 
 Upon request, a Test Team Rep will confirm your contribution(s) and assign you a badge. There will be a monthly review of contributions and badges will be awarded at that time. The Test Team will post updates on new profile badges awarded on the [Test Team blog](https://make.wordpress.org/test/). 


### PR DESCRIPTION
Submitting the PR for adding a Test Handbook page for Profile Badge details. 

Closes: https://github.com/WordPress/test-handbook/issues/19
